### PR TITLE
Fix ColorizedBackend to initialize Dispatcher

### DIFF
--- a/src/spoved/logger.cr
+++ b/src/spoved/logger.cr
@@ -78,6 +78,7 @@ module Spoved
 
   class ColorizedBackend < ::Log::IOBackend
     def initialize(@io = STDOUT)
+      super()
       @mutex = Mutex.new(:unchecked)
       @progname = File.basename(PROGRAM_NAME)
       @formatter = ColorizedFormat


### PR DESCRIPTION
Without this change I get the following error when compiling:
```
In lib/spoved/src/spoved/logger.cr:80:9

 80 | def initialize(@io = STDOUT)
          ^---------
Error: this 'initialize' doesn't initialize instance variable '@dispatcher' of Log::Backend, with Spoved::ColorizedBackend < Log::Backend, rendering it nilable
```

Just an idea how to fix it, works locally for me but there are probably also other ways.

After merging this, https://github.com/spoved/crafana.cr needs to be bumped to use the new version 🙂 

Related to https://github.com/crystal-lang/crystal/pull/9432